### PR TITLE
fix(print_format.py): setting of margin top and bottom

### DIFF
--- a/silent_print/silent_print_core/doctype/silent_print_format/silent_print_format.json
+++ b/silent_print/silent_print_core/doctype/silent_print_format/silent_print_format.json
@@ -24,7 +24,6 @@
   {
    "fieldname": "print_format",
    "fieldtype": "Link",
-   "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Print Format",
    "options": "Print Format",
@@ -55,12 +54,14 @@
    "description": "This is the label used to identify the printer in the Webapp Hardware Bridge",
    "fieldname": "default_print_type",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Default Print Type"
   },
   {
    "default": "Portrait",
    "fieldname": "orientation",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Orientation",
    "options": "Portrait\nLandscape"
   },
@@ -106,7 +107,7 @@
   }
  ],
  "links": [],
- "modified": "2024-07-05 16:01:41.034457",
+ "modified": "2024-10-03 12:12:55.728586",
  "modified_by": "Administrator",
  "module": "Silent Print Core",
  "name": "Silent Print Format",

--- a/silent_print/utils/print_format.py
+++ b/silent_print/utils/print_format.py
@@ -123,11 +123,8 @@ def get_pdf(html, options=None, output=None):
 
 
 def prepare_options(html, options):
-	print("\n", options, "\n")
 	if not options:
 		options = {}
-
-	passed_options = options.copy()
 
 	options.update({
 		'print-media-type': None,
@@ -153,15 +150,8 @@ def prepare_options(html, options):
 		options['cookie'] = [('sid', '{0}'.format(frappe.session.sid))]
 
 	# page size
-	# if not options.get("page-size"):
-	# 	options['page-size'] = frappe.db.get_single_value("Print Settings", "pdf_page_size") or "A4"
-
-	# override top and botton margin
-	if passed_options.get("margin-top"):
-		options["margin-top"] = passed_options["margin-top"]
-	if passed_options.get("margin-bottom"):
-		options["margin-bottom"] = passed_options["margin-bottom"]
-
+	if not options.get("page-size"):
+		options['page-size'] = frappe.db.get_single_value("Print Settings", "pdf_page_size") or "A4"
 
 	return html, options
 


### PR DESCRIPTION
Fix: 
Setting of margin top and bottom. 

Result:
![image](https://github.com/user-attachments/assets/9ef9ad84-c9b3-4ed3-8118-9094c7874ed6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the "Silent Print Format" configuration to display `default_print_type` and `orientation` in list views.
  
- **Bug Fixes**
  - Streamlined handling of PDF generation options, improving clarity and functionality.
  
- **Chores**
  - Removed the unused `print_silently` function to enhance code maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->